### PR TITLE
Fix Forager soft_off power state configuration

### DIFF
--- a/config/forager.conf
+++ b/config/forager.conf
@@ -1,0 +1,5 @@
+# Enable soft off feature
+CONFIG_ZMK_PM_SOFT_OFF=y
+
+# Enable GPIO key wakeup trigger (for waking from soft_off)
+CONFIG_ZMK_GPIO_KEY_WAKEUP_TRIGGER=y


### PR DESCRIPTION
Add forager.conf with CONFIG_ZMK_PM_SOFT_OFF=y to enable the soft_off behavior that was already defined in the keymap. Also enable CONFIG_ZMK_GPIO_KEY_WAKEUP_TRIGGER=y to support waking from soft_off.